### PR TITLE
 Generate artifacthub-pkg.yml file from metadata.yml #11 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v1
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.1.0
 
   release:
     needs: test
@@ -40,7 +40,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v1
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v3.1.0
     with:
       input-wasm: disallow_default_namespace
       oci-target: ghcr.io/kubewarden/policies/disallow-default-namespace

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SOURCE_FILES := $(shell test -e src/ && find src -type f)
+VERSION := $(shell sed --posix -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)
 
 policy.wasm: $(SOURCE_FILES) Cargo.*
 	cargo build --target=wasm32-wasi --release
 	cp target/wasm32-wasi/release/*.wasm policy.wasm
 
-annotated-policy.wasm: policy.wasm metadata.yml
-	kwctl annotate -m metadata.yml -o annotated-policy.wasm policy.wasm
+artifacthub-pkg.yml: metadata.yml Cargo.toml
+	$(warning If you are updating the artifacthub-pkg.yml file for a release, \
+	  remember to set the VERSION variable with the proper value. \
+	  To use the latest tag, use the following command:  \
+	  make VERSION=$$(git describe --tags --abbrev=0 | cut -c2-) annotated-policy.wasm)
+	kwctl scaffold artifacthub --metadata-path metadata.yml --version $(VERSION) \
+		--output artifacthub-pkg.yml
+
+annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
+	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm
 
 .PHONY: fmt
 fmt:
-	cargo fmt --all --
+	cargo fmt --all -- --check
 
 .PHONY: lint
 lint:
@@ -42,4 +51,4 @@ test: fmt lint
 .PHONY: clean
 clean:
 	cargo clean
-	rm -f policy.wasm annotated-policy.wasm
+	rm -f policy.wasm annotated-policy.wasm artifacthub-pkg.yml

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -17,26 +17,39 @@
 ---
 version: 0.1.0
 name: disallow-default-namespace
-displayName: disallow-default-namespace
-createdAt: '2022-07-19T16:39:10+02:00'
-description: Disallow usage of the default namespace
+displayName: Disallow default namespace
+createdAt: 2023-03-28T18:17:00.677489234Z
+description: A Kubewarden policy to disallow usage of the default namespace
 license: Apache-2.0
 homeURL: https://github.com/nlamirault/disallow-default-namespace
 containersImages:
 - name: policy
-  image: "ghcr.io/kubewarden/policies/disallow-default-namespace:v0.1.0"
-keywords:
-- this is freeform
+  image: ghcr.io/nlamirault/policies/disallow-default-namespace:v0.1.0
 links:
 - name: policy
   url: https://github.com/nlamirault/disallow-default-namespace/releases/download/v0.1.0/policy.wasm
 - name: source
   url: https://github.com/nlamirault/disallow-default-namespace
+install: |
+  The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
+  ```console
+  kwctl pull ghcr.io/nlamirault/policies/disallow-default-namespace:v0.1.0
+  ```
+maintainers:
+- name: Nicolas Lamirault
+  email: nicolas.lamirault@gmail.com
 provider:
   name: kubewarden
 recommendations:
 - url: https://artifacthub.io/packages/helm/kubewarden/kubewarden-controller
 annotations:
-  kubewarden/resources: Pod, Deployment, StatefulSet, DaemonSet, CronJob, Job # comma separated list
-  kubewarden/mutation: false
-  kubewarden/contextAware: false
+  kubewarden/mutation: 'false'
+  kubewarden/rules: |
+    - apiGroups:
+      - ''
+      apiVersions:
+      - v1
+      resources:
+      - pods
+      operations:
+      - CREATE

--- a/metadata.yml
+++ b/metadata.yml
@@ -24,12 +24,10 @@ contextAware: false
 executionMode: kubewarden-wapc
 annotations:
   io.kubewarden.policy.title: disallow-default-namespace
-  io.kubewarden.policy.description: Short description
+  io.artifacthub.displayName: Disallow default namespace
+  io.kubewarden.policy.description: A Kubewarden policy to disallow usage of the default namespace
   io.kubewarden.policy.author: Nicolas Lamirault <nicolas.lamirault@gmail.com>
   io.kubewarden.policy.url: https://github.com/nlamirault/disallow-default-namespace
   io.kubewarden.policy.source: https://github.com/nlamirault/disallow-default-namespace
   io.kubewarden.policy.license: Apache-2.0
-  io.kubewarden.policy.usage: |
-    Long explaination.
-
-    **Note well:** this can be Markdown text
+  io.kubewarden.policy.ociUrl: ghcr.io/nlamirault/policies/disallow-default-namespace #FIXME this needs to be a valid OCI URL.


### PR DESCRIPTION
Adds new makefile target to update the artifact-pkg.yml file using a recent added command in the kwctl. This command reads the content of the metadata.yml file and generates the artifact-pkg.yml based on that. This change also updates the Github action used in the CI to build, test and release the policy to the latest version v3.1.0. This version uses the latest kwctl command to generate the artifacthub-pkg.yml file from the metadata.yml file.

Fix #12 